### PR TITLE
chore: Upgrade typescript-eslint to v6.5 and update eslint rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,7 +8,8 @@ module.exports = {
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:import/typescript',
-    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
@@ -21,7 +22,7 @@ module.exports = {
     project: ['./tsconfig.json', './tsconfig.node.json'],
     tsconfigRootDir: __dirname,
   },
-  plugins: ['react-refresh', 'simple-import-sort', 'import', 'prettier'],
+  plugins: ['@typescript-eslint', 'react-refresh', 'simple-import-sort', 'import', 'prettier'],
   rules: {
     'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     '@typescript-eslint/no-non-null-assertion': 'off',
@@ -84,6 +85,9 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-unused-vars': ['error'],
+    '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+    '@typescript-eslint/prefer-ts-expect-error': 'error',
+    '@typescript-eslint/array-type': ['error', { default: 'generic' }],
 
     'prettier/prettier': ['error', {}, { usePrettierrc: true }],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,11 +40,11 @@
         "@types/node": "^20.4.4",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
-        "@typescript-eslint/eslint-plugin": "^5.61.0",
-        "@typescript-eslint/parser": "^5.61.0",
+        "@typescript-eslint/eslint-plugin": "^6.5.0",
+        "@typescript-eslint/parser": "^6.5.0",
         "@vitejs/plugin-react": "^4.0.1",
         "autoprefixer": "^10.4.14",
-        "eslint": "^8.46.0",
+        "eslint": "^8.48.0",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-import": "^2.27.5",
@@ -62,7 +62,7 @@
         "pretty-quick": "^3.1.3",
         "storybook": "^7.3.2",
         "tailwindcss": "^3.3.3",
-        "typescript": "^5.0.2",
+        "typescript": "^5.2.2",
         "vite": "^4.4.0"
       }
     },
@@ -2515,9 +2515,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
-      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -2538,9 +2538,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2565,9 +2565,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
-      "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6321,59 +6321,160 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.61.0.tgz",
-      "integrity": "sha512-A5l/eUAug103qtkwccSCxn8ZRwT+7RXWkFECdA4Cvl1dOlDUgTpAOfSEElZn2uSUxhdDpnCdetrf0jvU4qrL+g==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.5.0.tgz",
+      "integrity": "sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.61.0",
-        "@typescript-eslint/type-utils": "5.61.0",
-        "@typescript-eslint/utils": "5.61.0",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/type-utils": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
+      "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.61.0.tgz",
-      "integrity": "sha512-yGr4Sgyh8uO6fSi9hw3jAFXNBHbCtKKFMdX2IkT3ZqpKmtAq3lHS4ixB/COFuAIJpwl9/AqF7j72ZDWYKmIfvg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.5.0.tgz",
+      "integrity": "sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.61.0",
-        "@typescript-eslint/types": "5.61.0",
-        "@typescript-eslint/typescript-estree": "5.61.0",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -6381,14 +6482,88 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz",
-      "integrity": "sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==",
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.61.0",
-        "@typescript-eslint/visitor-keys": "5.61.0"
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6399,25 +6574,25 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.61.0.tgz",
-      "integrity": "sha512-kk8u//r+oVK2Aj3ph/26XdH0pbAkC2RiSjUYhKD+PExemG4XSjpGFeyZ/QM8lBOa7O8aGOU+/yEbMJgQv/DnCg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.5.0.tgz",
+      "integrity": "sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.61.0",
-        "@typescript-eslint/utils": "5.61.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -6425,10 +6600,109 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
+      "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.61.0.tgz",
-      "integrity": "sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6439,13 +6713,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz",
-      "integrity": "sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.61.0",
-        "@typescript-eslint/visitor-keys": "5.61.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -6466,17 +6740,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.61.0.tgz",
-      "integrity": "sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.61.0",
-        "@typescript-eslint/types": "5.61.0",
-        "@typescript-eslint/typescript-estree": "5.61.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -6492,12 +6766,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz",
-      "integrity": "sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.61.0",
+        "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -9072,15 +9346,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
-      "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.1",
-        "@eslint/js": "^8.46.0",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.48.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -9091,7 +9365,7 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.2",
+        "eslint-visitor-keys": "^3.4.3",
         "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
@@ -9475,9 +9749,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -13147,12 +13421,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true
-    },
     "node_modules/needle": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-3.2.0.tgz",
@@ -15787,9 +16055,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -16957,6 +17225,18 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -17124,9 +17404,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -19647,9 +19927,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.1.tgz",
-      "integrity": "sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -19664,9 +19944,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.20.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-          "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+          "version": "13.21.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+          "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -19681,9 +19961,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
-      "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
       "dev": true
     },
     "@fal-works/esbuild-plugin-global-externals": {
@@ -22287,71 +22567,232 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.61.0.tgz",
-      "integrity": "sha512-A5l/eUAug103qtkwccSCxn8ZRwT+7RXWkFECdA4Cvl1dOlDUgTpAOfSEElZn2uSUxhdDpnCdetrf0jvU4qrL+g==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.5.0.tgz",
+      "integrity": "sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==",
       "dev": true,
       "requires": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.61.0",
-        "@typescript-eslint/type-utils": "5.61.0",
-        "@typescript-eslint/utils": "5.61.0",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/type-utils": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+          "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.5.0",
+            "@typescript-eslint/visitor-keys": "6.5.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+          "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+          "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.5.0",
+            "@typescript-eslint/visitor-keys": "6.5.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
+          "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
+          "dev": true,
+          "requires": {
+            "@eslint-community/eslint-utils": "^4.4.0",
+            "@types/json-schema": "^7.0.12",
+            "@types/semver": "^7.5.0",
+            "@typescript-eslint/scope-manager": "6.5.0",
+            "@typescript-eslint/types": "6.5.0",
+            "@typescript-eslint/typescript-estree": "6.5.0",
+            "semver": "^7.5.4"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+          "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.5.0",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.61.0.tgz",
-      "integrity": "sha512-yGr4Sgyh8uO6fSi9hw3jAFXNBHbCtKKFMdX2IkT3ZqpKmtAq3lHS4ixB/COFuAIJpwl9/AqF7j72ZDWYKmIfvg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.5.0.tgz",
+      "integrity": "sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.61.0",
-        "@typescript-eslint/types": "5.61.0",
-        "@typescript-eslint/typescript-estree": "5.61.0",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+          "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.5.0",
+            "@typescript-eslint/visitor-keys": "6.5.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+          "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+          "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.5.0",
+            "@typescript-eslint/visitor-keys": "6.5.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+          "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.5.0",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz",
-      "integrity": "sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.61.0",
-        "@typescript-eslint/visitor-keys": "5.61.0"
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.61.0.tgz",
-      "integrity": "sha512-kk8u//r+oVK2Aj3ph/26XdH0pbAkC2RiSjUYhKD+PExemG4XSjpGFeyZ/QM8lBOa7O8aGOU+/yEbMJgQv/DnCg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.5.0.tgz",
+      "integrity": "sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.61.0",
-        "@typescript-eslint/utils": "5.61.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+          "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.5.0",
+            "@typescript-eslint/visitor-keys": "6.5.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+          "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+          "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.5.0",
+            "@typescript-eslint/visitor-keys": "6.5.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
+          "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
+          "dev": true,
+          "requires": {
+            "@eslint-community/eslint-utils": "^4.4.0",
+            "@types/json-schema": "^7.0.12",
+            "@types/semver": "^7.5.0",
+            "@typescript-eslint/scope-manager": "6.5.0",
+            "@typescript-eslint/types": "6.5.0",
+            "@typescript-eslint/typescript-estree": "6.5.0",
+            "semver": "^7.5.4"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+          "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.5.0",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        }
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.61.0.tgz",
-      "integrity": "sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz",
-      "integrity": "sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.61.0",
-        "@typescript-eslint/visitor-keys": "5.61.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -22360,28 +22801,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.61.0.tgz",
-      "integrity": "sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.61.0",
-        "@typescript-eslint/types": "5.61.0",
-        "@typescript-eslint/typescript-estree": "5.61.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz",
-      "integrity": "sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.61.0",
+        "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -24357,15 +24798,15 @@
       }
     },
     "eslint": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
-      "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.1",
-        "@eslint/js": "^8.46.0",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.48.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -24376,7 +24817,7 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.2",
+        "eslint-visitor-keys": "^3.4.3",
         "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
@@ -24746,9 +25187,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz",
-      "integrity": "sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true
     },
     "espree": {
@@ -27321,12 +27762,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true
-    },
     "needle": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-3.2.0.tgz",
@@ -29126,9 +29561,9 @@
       }
     },
     "semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -30036,6 +30471,13 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "ts-api-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+      "dev": true,
+      "requires": {}
+    },
     "ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -30163,9 +30605,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "@types/node": "^20.4.4",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
-    "@typescript-eslint/eslint-plugin": "^5.61.0",
-    "@typescript-eslint/parser": "^5.61.0",
+    "@typescript-eslint/eslint-plugin": "^6.5.0",
+    "@typescript-eslint/parser": "^6.5.0",
     "@vitejs/plugin-react": "^4.0.1",
     "autoprefixer": "^10.4.14",
-    "eslint": "^8.46.0",
+    "eslint": "^8.48.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
@@ -75,7 +75,7 @@
     "pretty-quick": "^3.1.3",
     "storybook": "^7.3.2",
     "tailwindcss": "^3.3.3",
-    "typescript": "^5.0.2",
+    "typescript": "^5.2.2",
     "vite": "^4.4.0"
   }
 }

--- a/src/components/elements/table/table.tsx
+++ b/src/components/elements/table/table.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { ArchiveBoxIcon } from '@heroicons/react/24/outline'
 
 type TableColumn<Entry> = {
@@ -48,7 +48,7 @@ export const Table = <Entry extends { id: string }>({ data, columns }: TableProp
                         key={`${title}${columnIndex}`}
                         className='whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900'
                       >
-                        {Cell ? <Cell entry={entry} /> : entry[field]}
+                        {Cell ? <Cell entry={entry} /> : (entry[field] as ReactNode)}
                       </td>
                     ))}
                   </tr>

--- a/src/components/elements/table/table.tsx
+++ b/src/components/elements/table/table.tsx
@@ -8,8 +8,8 @@ type TableColumn<Entry> = {
 }
 
 export type TableProps<Entry> = {
-  data: Entry[]
-  columns: TableColumn<Entry>[]
+  data: Array<Entry>
+  columns: Array<TableColumn<Entry>>
 }
 
 export const Table = <Entry extends { id: string }>({ data, columns }: TableProps<Entry>) => {

--- a/src/components/form/select-field.tsx
+++ b/src/components/form/select-field.tsx
@@ -6,11 +6,11 @@ import { FieldWrapper, FieldWrapperPassThroughProps } from './field-wrapper'
 
 type Option = {
   label: ReactNode
-  value: string | number | string[]
+  value: string | number | Array<string>
 }
 
 type SelectFieldProps = FieldWrapperPassThroughProps & {
-  options: Option[]
+  options: Array<Option>
   className?: string
   defaultValue?: string
   placeholder?: string

--- a/src/components/layout/main-layout.tsx
+++ b/src/components/layout/main-layout.tsx
@@ -19,9 +19,9 @@ import {
 import clsx from 'clsx'
 
 import logo from '@/assets/react.svg'
+import { USER_ROLES } from '@/features/auth'
 import { useAuthorization } from '@/hooks/use-authorization'
 import { useLogout } from '@/lib/auth'
-import { ROLES } from '@/lib/authorization'
 
 type SideNavigationItem = {
   name: string
@@ -33,12 +33,12 @@ const SideNavigation = () => {
   const { checkAccess } = useAuthorization()
   const navigation = [
     { name: 'Dashboard', to: '.', icon: HomeIcon },
-    checkAccess({ allowedRoles: [ROLES.ADMIN] }) && {
+    checkAccess({ allowedRoles: [USER_ROLES.ADMIN] }) && {
       name: 'Users',
       to: './users',
       icon: UsersIcon,
     },
-  ].filter(Boolean) as SideNavigationItem[]
+  ].filter(Boolean) as Array<SideNavigationItem>
 
   return (
     <>
@@ -87,7 +87,7 @@ const UserNavigation = () => {
         logout.mutate()
       },
     },
-  ].filter(Boolean) as UserNavigationItem[]
+  ].filter(Boolean) as Array<UserNavigationItem>
 
   return (
     <Menu as='div' className='relative ml-3'>

--- a/src/features/auth/components/login-form.tsx
+++ b/src/features/auth/components/login-form.tsx
@@ -34,13 +34,13 @@ export const LoginForm = ({ onSuccess }: LoginFormProps) => {
             <InputField
               type='text'
               label='Username'
-              error={formState.errors['identifier']}
+              error={formState.errors.identifier}
               registration={register('identifier')}
             />
             <InputField
               type='password'
               label='Password'
-              error={formState.errors['password']}
+              error={formState.errors.password}
               registration={register('password')}
             />
             <div>

--- a/src/features/auth/components/register-form.tsx
+++ b/src/features/auth/components/register-form.tsx
@@ -62,25 +62,25 @@ export const RegisterForm = ({ onSuccess }: RegisterFormProps) => {
             <InputField
               type='text'
               label='First Name'
-              error={formState.errors['firstName']}
+              error={formState.errors.firstName}
               registration={register('firstName')}
             />
             <InputField
               type='text'
               label='Last Name'
-              error={formState.errors['lastName']}
+              error={formState.errors.lastName}
               registration={register('lastName')}
             />
             <InputField
               type='email'
               label='Email Address'
-              error={formState.errors['email']}
+              error={formState.errors.email}
               registration={register('email')}
             />
             <InputField
               type='password'
               label='Password'
-              error={formState.errors['password']}
+              error={formState.errors.password}
               registration={register('password')}
             />
 
@@ -106,7 +106,7 @@ export const RegisterForm = ({ onSuccess }: RegisterFormProps) => {
             {chooseTeam && teamsQuery?.data ? (
               <SelectField
                 label='Team'
-                error={formState.errors['teamId']}
+                error={formState.errors.teamId}
                 registration={register('teamId')}
                 options={teamsQuery.data.map((team) => ({
                   label: team.name,
@@ -117,7 +117,7 @@ export const RegisterForm = ({ onSuccess }: RegisterFormProps) => {
               <InputField
                 type='text'
                 label='Team Name'
-                error={formState.errors['teamName']}
+                error={formState.errors.teamName}
                 registration={register('teamName')}
               />
             )}

--- a/src/features/auth/consts/index.ts
+++ b/src/features/auth/consts/index.ts
@@ -1,0 +1,1 @@
+export * from './user-roles'

--- a/src/features/auth/consts/user-roles.ts
+++ b/src/features/auth/consts/user-roles.ts
@@ -1,0 +1,4 @@
+export const USER_ROLES = {
+  ADMIN: 'ADMIN',
+  USER: 'USER',
+} as const

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,4 +1,5 @@
 export * from './api'
 export * from './components'
+export * from './consts'
 export * from './routes'
 export * from './types'

--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -1,4 +1,6 @@
-import { ROLES } from '@/lib/authorization'
+import { USER_ROLES } from '@/features/auth'
+
+export type UserRole = keyof typeof USER_ROLES
 
 export type GetUserResponse = {
   bio: string
@@ -7,7 +9,7 @@ export type GetUserResponse = {
   id: string
   lastName: string
   role: {
-    name: ROLES
+    name: UserRole
   }
   teamId: string
 }
@@ -18,7 +20,7 @@ export type AuthUser = {
   firstName: string
   id: string
   lastName: string
-  role: ROLES
+  role: UserRole
 }
 
 export type UserResponse = {

--- a/src/features/misc/routes/dashboard.tsx
+++ b/src/features/misc/routes/dashboard.tsx
@@ -1,6 +1,6 @@
 import { ContentLayout } from '@/components/layout'
+import { USER_ROLES } from '@/features/auth'
 import { useUser } from '@/lib/auth'
-import { ROLES } from '@/lib/authorization'
 
 export const Dashboard = () => {
   const { user } = useUser()
@@ -17,13 +17,13 @@ export const Dashboard = () => {
         Your role is: <b>{user?.role}</b>
       </h4>
       <p className='font-medium'>In this application you can:</p>
-      {user?.role === ROLES.USER && (
+      {user?.role === USER_ROLES.USER && (
         <ul className='my-4 list-inside list-disc'>
           <li>Create comments in discussions</li>
           <li>Delete own comments</li>
         </ul>
       )}
-      {user?.role === ROLES.ADMIN && (
+      {user?.role === USER_ROLES.ADMIN && (
         <ul className='my-4 list-inside list-disc'>
           <li>Create discussions</li>
           <li>Edit discussions</li>

--- a/src/features/teams/api/get-teams.ts
+++ b/src/features/teams/api/get-teams.ts
@@ -5,7 +5,7 @@ import { axios } from '@/lib/axios'
 import { Team } from '../types'
 
 type GetTeamsResponse = {
-  roles: Team[]
+  roles: Array<Team>
 }
 
 type UseTeamsOptions = {

--- a/src/features/users/api/delete-user.ts
+++ b/src/features/users/api/delete-user.ts
@@ -22,7 +22,7 @@ export const useDeleteUser = () => {
     onMutate: async (deletedUser) => {
       await queryClient.cancelQueries(['users'])
 
-      const previousUsers = queryClient.getQueryData<User[]>(['users'])
+      const previousUsers = queryClient.getQueryData<Array<User>>(['users'])
 
       queryClient.setQueryData(
         ['users'],

--- a/src/features/users/api/get-users.ts
+++ b/src/features/users/api/get-users.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { ROLES } from '@/lib/authorization'
+import { UserRole } from '@/features/auth'
 import { axios } from '@/lib/axios'
 import { BaseEntity } from '@/types'
 
@@ -10,17 +10,17 @@ type GetUsersResponse = {
   firstName: string
   lastName: string
   email: string
-  role: { name: ROLES }
+  role: { name: UserRole }
   teamId: string
   bio: string
 } & BaseEntity
 
 export const getUsers = async () => {
-  const response = await axios.get<GetUsersResponse[]>('/users?populate=role')
+  const response = await axios.get<Array<GetUsersResponse>>('/users?populate=role')
   return response.data
 }
 
-const mapUsersWithRole = (users: GetUsersResponse[]): User[] =>
+const mapUsersWithRole = (users: Array<GetUsersResponse>): Array<User> =>
   users.map((user) => ({ ...user, role: user.role.name }))
 
 export const useUsers = () =>

--- a/src/features/users/components/update-profile.tsx
+++ b/src/features/users/components/update-profile.tsx
@@ -56,24 +56,24 @@ export const UpdateProfile = () => {
           <>
             <InputField
               label='First Name'
-              error={formState.errors['firstName']}
+              error={formState.errors.firstName}
               registration={register('firstName')}
             />
             <InputField
               label='Last Name'
-              error={formState.errors['lastName']}
+              error={formState.errors.lastName}
               registration={register('lastName')}
             />
             <InputField
               label='Email Address'
               type='email'
-              error={formState.errors['email']}
+              error={formState.errors.email}
               registration={register('email')}
             />
 
             <TextAreaField
               label='Bio'
-              error={formState.errors['bio']}
+              error={formState.errors.bio}
               registration={register('bio')}
             />
           </>

--- a/src/features/users/routes/users.tsx
+++ b/src/features/users/routes/users.tsx
@@ -1,6 +1,7 @@
 import { ContentLayout } from '@/components/layout'
+import { USER_ROLES } from '@/features/auth'
 import { UsersList } from '@/features/users'
-import { Authorization, ROLES } from '@/lib/authorization'
+import { Authorization } from '@/lib/authorization'
 
 export const Users = () => {
   return (
@@ -8,7 +9,7 @@ export const Users = () => {
       <div className='mt-4'>
         <Authorization
           forbiddenFallback={<div>Only admin can view this.</div>}
-          allowedRoles={[ROLES.ADMIN]}
+          allowedRoles={[USER_ROLES.ADMIN]}
         >
           <UsersList />
         </Authorization>

--- a/src/features/users/types/index.ts
+++ b/src/features/users/types/index.ts
@@ -1,10 +1,11 @@
+import { UserRole } from '@/features/auth'
 import { BaseEntity } from '@/types'
 
 export type User = {
   firstName: string
   lastName: string
   email: string
-  role: 'ADMIN' | 'USER'
+  role: UserRole
   teamId: string
   bio: string
 } & BaseEntity

--- a/src/hooks/use-authorization.ts
+++ b/src/hooks/use-authorization.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 
+import { UserRole } from '@/features/auth'
 import { useUser } from '@/lib/auth'
-import { RoleTypes } from '@/lib/authorization'
 
 export const useAuthorization = () => {
   const { user } = useUser()
@@ -13,7 +13,7 @@ export const useAuthorization = () => {
   const { role } = user
 
   const checkAccess = useCallback(
-    ({ allowedRoles }: { allowedRoles: RoleTypes[] }) => {
+    ({ allowedRoles }: { allowedRoles: Array<UserRole> }) => {
       if (allowedRoles && allowedRoles.length > 0) {
         return allowedRoles?.includes(role)
       }

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -94,7 +94,7 @@ export const provideAuth = <UserData, LoginCredentials, RegisterCredentials>({
   }
 
   const useLogin = (options?: TUserLoginOptions<UserData, LoginCredentials>) => {
-    const { onSuccess, ...mutateOptions } = options || {}
+    const { onSuccess, ...mutateOptions } = options ?? {}
     const queryClient = useQueryClient()
 
     return useMutation({
@@ -102,13 +102,13 @@ export const provideAuth = <UserData, LoginCredentials, RegisterCredentials>({
       ...mutateOptions,
       onSuccess: (user, variables, context) => {
         queryClient.setQueryData(userKey, user)
-        onSuccess && onSuccess(user, variables, context)
+        onSuccess?.(user, variables, context)
       },
     })
   }
 
   const useRegister = (options?: TUserRegisterOptions<UserData, RegisterCredentials>) => {
-    const { onSuccess, ...mutateOptions } = options || {}
+    const { onSuccess, ...mutateOptions } = options ?? {}
     const queryClient = useQueryClient()
 
     return useMutation({
@@ -116,13 +116,13 @@ export const provideAuth = <UserData, LoginCredentials, RegisterCredentials>({
       ...mutateOptions,
       onSuccess: (user, variables, context) => {
         queryClient.setQueryData(userKey, user)
-        onSuccess && onSuccess(user, variables, context)
+        onSuccess?.(user, variables, context)
       },
     })
   }
 
   const useLogout = (options?: TUserLogoutOptions) => {
-    const { onSuccess, ...mutateOptions } = options || {}
+    const { onSuccess, ...mutateOptions } = options ?? {}
     const queryClient = useQueryClient()
 
     return useMutation({
@@ -130,7 +130,7 @@ export const provideAuth = <UserData, LoginCredentials, RegisterCredentials>({
       ...mutateOptions,
       onSuccess: (...args) => {
         queryClient.setQueryData(userKey, null)
-        onSuccess && onSuccess(...args)
+        onSuccess?.(...args)
       },
     })
   }

--- a/src/lib/authorization.tsx
+++ b/src/lib/authorization.tsx
@@ -1,20 +1,14 @@
 import { ReactNode } from 'react'
 
+import { UserRole } from '@/features/auth'
 import { useAuthorization } from '@/hooks/use-authorization'
-
-export enum ROLES {
-  ADMIN = 'ADMIN',
-  USER = 'USER',
-}
-
-export type RoleTypes = keyof typeof ROLES
 
 type AuthorizationProps = {
   forbiddenFallback?: ReactNode
   children: ReactNode
 } & (
   | {
-      allowedRoles: RoleTypes[]
+      allowedRoles: Array<UserRole>
       policyCheck?: never
     }
   | {

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -21,12 +21,9 @@ axios.interceptors.request.use(onRequestSuccess)
 axios.interceptors.response.use(
   (response) => response,
   (error: AxiosError) => {
-    const message =
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      (error.response?.data.error?.message as string) || error.message
-
+    // @ts-expect-error: unsafely accessing error object
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const message = (error.response?.data.error?.message as string) || error.message
     useNotificationStore.getState().addNotification({
       type: 'error',
       title: 'Error',

--- a/src/stores/notifications.ts
+++ b/src/stores/notifications.ts
@@ -9,7 +9,7 @@ export type Notification = {
 }
 
 type NotificationsStore = {
-  notifications: Notification[]
+  notifications: Array<Notification>
   addNotification: (notification: Omit<Notification, 'id'>) => void
   dismissNotification: (id: string) => void
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -2,7 +2,8 @@ const storagePrefix = 'my_app_react_'
 
 const storage = {
   getToken: () => {
-    return JSON.parse(window.localStorage.getItem(`${storagePrefix}token`) as string) as string
+    const token = window.localStorage.getItem(`${storagePrefix}token`) ?? ''
+    return JSON.parse(token) as string
   },
   setToken: (token: string) => {
     window.localStorage.setItem(`${storagePrefix}token`, JSON.stringify(token))


### PR DESCRIPTION
In this commit:
- Upgraded typescript-eslint to version 6.5 for enhanced features and performance improvements.
- Added and refined eslint rules to ensure consistent code quality and maintainability.